### PR TITLE
Add midpoint method and a test

### DIFF
--- a/Geometry.jl
+++ b/Geometry.jl
@@ -40,7 +40,7 @@ struct Point2D
     end
 end
 Base.show(io::IO,p::Point2D) = print(io, string((p.x,p.y)))
-Base.:(==)(p1::Point2D, p2::Point2D)= p1.x == p2.x && p1.y == p2.y 
+Base.:(==)(p1::Point2D, p2::Point2D)= p1.x == p2.x && p1.y == p2.y
 
 
 
@@ -126,7 +126,7 @@ struct Polygon
     # Outer constructor with Varargs of Real, calls the inner constructor with Vector{Real}
     Polygon(coords::Real...) = Polygon(collect(coords))
 
-  
+
 end
 
 function Base.:(==)(p1::Polygon,p2::Polygon)
@@ -212,6 +212,13 @@ function perimeter(idk::Polygon)
         return isapprox(distance2D(idk.points[1],idk.points[3]),distance2D(idk.points[2],idk.points[4]))
     end
 end
+
+
+"""
+midpoint(p::Polyon)
+calculates the midpoint of the polygon.
+"""
+midpoint(p::Polygon) = Point2D(mean(map(pt -> pt.x, p.pts)), mean(map(pt -> pt.y, p.pts)))
 
 
 end # Geometry module

--- a/GeometryTest.jl
+++ b/GeometryTest.jl
@@ -7,7 +7,7 @@ import Base.:(==)
 
     @testset "Point2D" begin
         @test isa(Point2D(1,4),Point2D)
-        @test isa(Point2D(-1,2),Point2D)    
+        @test isa(Point2D(-1,2),Point2D)
         @test isa(Point2D(-3.14,4.13),Point2D)
         @test isa(Point2D(1.1,2.2),Point2D)
         @test isa(Point2D(1.2,0),Point2D)
@@ -21,7 +21,7 @@ import Base.:(==)
 
     @testset "Point3D" begin
         @test isa(Point3D(1,4, 7),Point3D)
-        @test isa(Point3D(-1,2,3),Point3D)    
+        @test isa(Point3D(-1,2,3),Point3D)
         @test isa(Point3D(-3.14,4.13,0.01),Point3D)
         @test isa(Point3D(1.1,2.2,3.3),Point3D)
         @test isa(Point3D(1.2,4.76,0),Point3D)
@@ -30,21 +30,21 @@ import Base.:(==)
     tri = [1,3,4,1,1,1]
     @testset "Triangle" begin
         @test isa(Polygon([Point2D(1,3),Point2D(4,1),Point2D(1,1)]),Polygon)
-        @test isa(Polygon(1,3,4,1,1,1),Polygon) 
-        @test isa(Polygon(tri),Polygon) 
+        @test isa(Polygon(1,3,4,1,1,1),Polygon)
+        @test isa(Polygon(tri),Polygon)
     end
 
     rec = [1,3,5,3,5,1,1,1]
     @testset " Rectangle" begin
-        @test isa(Polygon([Point2D(1,3),Point2D(5,3),Point2D(5,1),Point2D(1,1)]),Polygon) 
-        @test isa(Polygon(1,3,5,3,5,1,1,1),Polygon) 
-        @test isa(Polygon(rec),Polygon) 
+        @test isa(Polygon([Point2D(1,3),Point2D(5,3),Point2D(5,1),Point2D(1,1)]),Polygon)
+        @test isa(Polygon(1,3,5,3,5,1,1,1),Polygon)
+        @test isa(Polygon(rec),Polygon)
     end
 
     par = [2,3,5,3,4,1,1,1]
     @testset " Parallelogram" begin
-        @test isa(Polygon([Point2D(2,3),Point2D(5,3),Point2D(4,1),Point2D(1,1)]),Polygon) 
-        @test isa(Polygon(2,3,5,3,4,1,1,1),Polygon) 
+        @test isa(Polygon([Point2D(2,3),Point2D(5,3),Point2D(4,1),Point2D(1,1)]),Polygon)
+        @test isa(Polygon(2,3,5,3,4,1,1,1),Polygon)
         @test isa(Polygon(par),Polygon)
     end
 
@@ -81,9 +81,9 @@ import Base.:(==)
     #5
 
     @testset "Distance" begin
-        @test isapprox(distance2D(p1,p2),distance2D(p3,p4)) 
-        @test isapprox(distance2D(p5,p6), distance2D(p7,p8)) 
-        @test isapprox(distance2D(p9,p10),distance2D(p11,p12)) 
+        @test isapprox(distance2D(p1,p2),distance2D(p3,p4))
+        @test isapprox(distance2D(p5,p6), distance2D(p7,p8))
+        @test isapprox(distance2D(p9,p10),distance2D(p11,p12))
     end
 
     triangle = Polygon([Point2D(1,3),Point2D(4,1),Point2D(1,1)]) # 8.6055512755
@@ -92,7 +92,12 @@ import Base.:(==)
 
     @testset "Perimeter" begin
         @test isapprox(perimeter(triangle), 8.6055512755)
-        @test isapprox(perimeter(rectangle), 12) 
-        @test isapprox(perimeter(parallelogram), 10.4721359550) 
+        @test isapprox(perimeter(rectangle), 12)
+        @test isapprox(perimeter(parallelogram), 10.4721359550)
     end
 
+
+    @testset "Midpoint caclulations" begin
+        @test midpoint(triangle) == Point2D(1/3,1/3)
+        @test midpoint(rectangle) == Point2D(0.5,1)
+    end


### PR DESCRIPTION
This adds a midpoint method for a Polygon and provides a test for the midpoint of a triangle and a rectangle.